### PR TITLE
Enable multiple packages

### DIFF
--- a/check-pkg/action.yaml
+++ b/check-pkg/action.yaml
@@ -26,32 +26,40 @@ runs:
     - name: Check CRAN checks
       id: cran-check-status
       run: |
-        pkg <- "${{ inputs.pkg }}"
-        fp <- paste0("https://flrsh-dev.github.io/cran-checks/", pkg, ".json")
-
-        json <- tryCatch(readLines(fp),
-          warning = function(e) {
-            stop("Package ", pkg, " not found in CRAN checks", call. = FALSE)
-          }
-        )
-
-        res <- yyjsonr::read_json_str(json)
+        pkgs <- unlist(strsplit("${{ inputs.pkg }}", "\\s+"))
+        pkgs <- pkgs[pkgs != ""]
         
-        if (any("ERROR" %in% res$results[[1]]$check_status)) {
-          stop(
-            "Errors found in CRAN checks",
-            "\n",
-            "Review logs at ", 
-            "https://cran.r-project.org/web/checks/check_results_", pkg, ".html"
+        pkg_errs <- character(0)
+        pkg_warn <- character(0)
+        for(pkg in pkgs) {
+          fp <- paste0("https://flrsh-dev.github.io/cran-checks/", pkg, ".json")
+        
+          json <- tryCatch(readLines(fp),
+                           warning = function(e) {
+                             stop("Package ", pkg, " not found in CRAN checks", call. = FALSE)
+                           }
           )
-        } else if (any("WARN" %in% res$results[[1]]$check_status)) {
-          stop(
-            "Warnings found in CRAN checks",
-            "\n",
-            "Review logs at ", 
-            "https://cran.r-project.org/web/checks/check_results_", pkg, ".html"
-          )
+        
+          res <- yyjsonr::read_json_str(json)
+        
+          if (any("ERROR" %in% res$results[[1]]$check_status)) {
+            pkg_errs <- c(pkg_errs, pkg)
+          } else if (any("WARN" %in% res$results[[1]]$check_status)) {
+            pkg_warn <- c(pkg_warn, pkg)
+          }
         }
         
-        message("\u2713 `", pkg, "` has no warnings or errors")
+        msg <- ""
+        if(length(pkg_errs) > 0) {
+          msg <- paste0("Errors found in CRAN checks for ", paste0("{", pkg_errs, "}", collapse = ", "), ". ")
+        }
+        if(length(pkg_warn) > 0) {
+          msg <- paste0(msg, "Warnings found in CRAN checks for ", paste0("{", pkg_warn, "}", collapse = ", "), ".")
+        }
+        if(nchar(msg) > 0) {
+          msg <- paste0(msg, "\n\nReview logs at:\n", paste0("  https://cran.r-project.org/web/checks/check_results_", c(pkg_errs, pkg_warn), ".html", collapse = "\n"))
+          stop(msg)
+        }
+        
+        message("\u2713 No warnings or errors for ", paste0("{", pkgs, "}", collapse = ", "), ".")
       shell: Rscript {0}

--- a/check-pkg/action.yaml
+++ b/check-pkg/action.yaml
@@ -29,6 +29,7 @@ runs:
         pkgs <- unlist(strsplit("${{ inputs.pkg }}", "\\s+"))
         pkgs <- pkgs[pkgs != ""]
         
+        pkg_miss <- character(0)
         pkg_errs <- character(0)
         pkg_warn <- character(0)
         for(pkg in pkgs) {
@@ -36,9 +37,13 @@ runs:
         
           json <- tryCatch(readLines(fp),
                            warning = function(e) {
-                             stop("Package ", pkg, " not found in CRAN checks", call. = FALSE)
+                             return(NULL)
                            }
           )
+          if(is.null(json)) {
+            pkg_miss <- c(pkg_miss, pkg)
+            next
+          }
         
           res <- yyjsonr::read_json_str(json)
         
@@ -50,8 +55,11 @@ runs:
         }
         
         msg <- ""
+        if(length(pkg_miss) > 0) {
+          msg <- paste0("Cannot find ", paste0("{", pkg_miss, "}", collapse = ", "), " on CRAN. ")
+        }
         if(length(pkg_errs) > 0) {
-          msg <- paste0("Errors found in CRAN checks for ", paste0("{", pkg_errs, "}", collapse = ", "), ". ")
+          msg <- paste0(msg, "Errors found in CRAN checks for ", paste0("{", pkg_errs, "}", collapse = ", "), ". ")
         }
         if(length(pkg_warn) > 0) {
           msg <- paste0(msg, "Warnings found in CRAN checks for ", paste0("{", pkg_warn, "}", collapse = ", "), ".")


### PR DESCRIPTION
This patch enables the user to specify multiple packages within a single GHA run. The run will check all the packages and report any errors or warnings across the full set of packages.

Multiple packages are simply separated with whitespace, for example (using action in my fork):

```{yaml}
name: Check CRAN status

on:
  schedule:
    # Runs daily at 4:00 PM UTC (9:00 AM PST)
    - cron: '0 16 * * *'
  # allows for manually running of the check
  workflow_dispatch:

jobs:
  check_cran_status:
    runs-on: ubuntu-latest

    steps:
      - name: Get CRAN checks (louisaslett fork)
        uses: louisaslett/cran-checks/check-pkg@main
        with:
          pkg: |
            PhaseType
            abn
            mlmc
            data.table
```

will check the packages {PhaseType}, {abn}, {mlmc}, and {data.table}.  In this instance, the resulting output is:

```
Error: Error: Errors found in CRAN checks for {abn}, {data.table}. 

Review logs at:
  https://cran.r-project.org/web/checks/check_results_abn.html
  https://cran.r-project.org/web/checks/check_results_data.table.html
```

This could possibly be further improved, but I was aiming for the minimal changes to achieve multi-package support!
