### PR TITLE
chore: enable shared agent instructions

### DIFF
--- a/.github/workflows/instructions.yaml
+++ b/.github/workflows/instructions.yaml
@@ -1,0 +1,34 @@
+name: Instructions
+
+on:
+  pull_request:
+    types: [opened, synchronize, edited, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+jobs:
+  paired-pr:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.agent_instructions_token }}
+    steps:
+      - name: Load shared instructions
+        run: gh repo clone ricochet-rs/agent-instructions "$RUNNER_TEMP/agent-instructions" -- --depth=1
+      - name: Validate paired instructions PR
+        run: >-
+          "$RUNNER_TEMP/agent-instructions/scripts/paired-instructions-pr.sh"
+          check "$GITHUB_REPOSITORY" "${{ github.event.pull_request.number }}"
+
+  merge-paired-pr:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.agent_instructions_token }}
+    steps:
+      - name: Load shared instructions
+        run: gh repo clone ricochet-rs/agent-instructions "$RUNNER_TEMP/agent-instructions" -- --depth=1
+      - name: Merge paired instructions PR
+        run: >-
+          "$RUNNER_TEMP/agent-instructions/scripts/paired-instructions-pr.sh"
+          merge-for-commit "$GITHUB_REPOSITORY" "$GITHUB_SHA"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Codex instructions
+
+Before doing any work, read `CLAUDE.md` completely and follow it.
+If `CLAUDE.md` cannot be read, stop and report the failure.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# Required Ricochet instructions
+
+Before inspecting repository files, planning, editing, or running project commands, ensure the shared instructions are available.
+
+1. Use `~/.cache/ricochet-rs/agent-instructions` as the shared checkout.
+2. If the checkout is absent, clone `git@github.com:ricochet-rs/agent-instructions.git` there.
+3. Fetch `origin/main` and check it out in detached-HEAD mode.
+4. Verify that cached `HEAD` exactly matches `origin/main`.
+5. Verify that `instructions/global.md`, `.codex-plugin/plugin.json`, and every selected `SKILL.md` exist.
+6. Read `instructions/global.md`.
+7. Read and follow `skills/development-flow/SKILL.md` for code changes.
+8. Read the applicable language skills according to the repository manifests and files involved.
+
+The shared skills may not appear in the startup skill catalog.
+Read their `SKILL.md` files directly from the shared checkout and follow them for the current session.
+
+If authentication, synchronization, HEAD validation, or a required read fails, stop before modifying the repository and report the failure clearly.
+Do not silently continue with missing or stale shared instructions.


### PR DESCRIPTION
This repository now loads current Ricochet organization guidance and enforces the paired-instructions lifecycle in CI.

<details>
<summary>AI Summary</summary>

This change adds the repository-neutral bootstrap for Codex and Claude while preserving existing repository-specific instructions.

The CI entry point clones `ricochet-rs/agent-instructions` from shared `main` at runtime and delegates validation and post-merge handling to the centralized checker.
Future checker fixes therefore land once in the shared repository rather than being copied across consumers.

Validation:

- Repository pre-commit hooks when configured
- CI configuration parsing or `crow lint`
- `git diff --check`

</details>

Instructions-PR: none
